### PR TITLE
Update C++ bindings to vodozemac-0.7.0 (first draft / request for comments)

### DIFF
--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vodozemac-cpp"
-version = "0.1.0"
+version = "0.7.0"
 edition = "2021"
 
 [lib]
@@ -13,7 +13,8 @@ cxx = "1.0"
 
 [dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"
-rev = "ce21316266fabaa3717363d5f410fb7943ecdb10"
+#rev = "ce21316266fabaa3717363d5f410fb7943ecdb10"
+rev = "92d6acca73b619a28440003f22c89b4127dd3fdb"
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,0 +1,33 @@
+# Building from source.
+
+Prerequisites: You will need a rust compiler, together with its default dependency manager, "cargo".
+
+ 1. Download the sources
+ ```
+ git clone https://github.com/matrix-org/vodozemac-bindings.git
+ ```
+
+ 2. Change to the directory with the c++ bindings.
+ ```
+ cd vodozemac-bindings/cpp
+ ```
+
+ 3. Compile
+ ```
+ cargo build --release
+ ```
+
+This will produce:
+
+ 1. a c++ header at
+`../target/cxxbridge/vodozemac/src/lib.rs.h`
+
+ 2. a c++ source file that represents the C++ side of the bindings at
+`../target/cxxbridge/vodozemac/src/lib.rs.cpp`
+
+ 3. a static library that represents the Rust side of the bridge at
+ ../target/release/libvodozemac.a
+
+# Usage.
+
+Please, take a look at the `.cpp` files inside the `tests` directory for the examples.

--- a/cpp/src/account.rs
+++ b/cpp/src/account.rs
@@ -1,6 +1,6 @@
 use super::{
     ffi::{InboundCreationResult, OlmMessageParts, OneTimeKey},
-    Curve25519PublicKey, Ed25519PublicKey, Ed25519Signature, Session, SessionConfig
+    Curve25519PublicKey, Ed25519PublicKey, Ed25519Signature, Session, OlmSessionConfig
 };
 
 pub struct OlmMessage(pub(crate) vodozemac::olm::OlmMessage);
@@ -117,7 +117,7 @@ impl Account {
 
     pub fn create_outbound_session(
         &self,
-        session_config: &SessionConfig,
+        session_config: &OlmSessionConfig,
         identity_key: &Curve25519PublicKey,
         one_time_key: &Curve25519PublicKey,
     ) -> Result<Box<Session>, vodozemac::KeyError> {

--- a/cpp/src/group_sessions.rs
+++ b/cpp/src/group_sessions.rs
@@ -1,10 +1,12 @@
 use super::ffi::DecryptedMessage;
 use anyhow::{anyhow, Result};
 
+pub struct SessionConfig(vodozemac::megolm::SessionConfig);
+
 pub struct GroupSession(vodozemac::megolm::GroupSession);
 
-pub fn new_group_session() -> Box<GroupSession> {
-    GroupSession::new().into()
+pub fn new_group_session(session_config: &SessionConfig) -> Box<GroupSession> {
+    GroupSession::new(session_config).into()
 }
 
 pub struct MegolmMessage(vodozemac::megolm::MegolmMessage);
@@ -44,8 +46,8 @@ impl ExportedSessionKey {
 }
 
 impl GroupSession {
-    fn new() -> Self {
-        Self(vodozemac::megolm::GroupSession::new())
+    fn new(session_config: &SessionConfig) -> Self {
+        Self(vodozemac::megolm::GroupSession::new(session_config.0))
     }
 
     pub fn session_id(&self) -> String {
@@ -76,12 +78,12 @@ pub fn group_session_from_pickle(pickle: &str, pickle_key: &[u8; 32]) -> Result<
 
 pub struct InboundGroupSession(vodozemac::megolm::InboundGroupSession);
 
-pub fn new_inbound_group_session(session_key: &SessionKey) -> Box<InboundGroupSession> {
-    InboundGroupSession::new(session_key).into()
+pub fn new_inbound_group_session(session_key: &SessionKey, session_config: &SessionConfig) -> Box<InboundGroupSession> {
+    InboundGroupSession::new(session_key, session_config).into()
 }
 
-pub fn import_inbound_group_session(session_key: &ExportedSessionKey) -> Box<InboundGroupSession> {
-    InboundGroupSession::import(session_key).into()
+pub fn import_inbound_group_session(session_key: &ExportedSessionKey, session_config: &SessionConfig) -> Box<InboundGroupSession> {
+    InboundGroupSession::import(session_key, &session_config).into()
 }
 
 pub fn inbound_group_session_from_pickle(
@@ -93,13 +95,14 @@ pub fn inbound_group_session_from_pickle(
 }
 
 impl InboundGroupSession {
-    fn new(session_key: &SessionKey) -> Self {
-        Self(vodozemac::megolm::InboundGroupSession::new(&session_key.0))
+    fn new(session_key: &SessionKey, session_config: &SessionConfig) -> Self {
+        Self(vodozemac::megolm::InboundGroupSession::new(&session_key.0, session_config.0))
     }
 
-    fn import(session_key: &ExportedSessionKey) -> Self {
+    fn import(session_key: &ExportedSessionKey, session_config: &SessionConfig) -> Self {
         Self(vodozemac::megolm::InboundGroupSession::import(
             &session_key.0,
+            session_config.0,
         ))
     }
 

--- a/cpp/src/group_sessions.rs
+++ b/cpp/src/group_sessions.rs
@@ -1,11 +1,23 @@
 use super::ffi::DecryptedMessage;
 use anyhow::{anyhow, Result};
 
-pub struct SessionConfig(vodozemac::megolm::SessionConfig);
+pub struct MegolmSessionConfig(vodozemac::megolm::SessionConfig);
+
+pub fn megolm_session_config_version_1() -> Box<MegolmSessionConfig> {
+    MegolmSessionConfig(vodozemac::megolm::SessionConfig::version_1()).into()
+}
+
+pub fn megolm_session_config_version_2() -> Box<MegolmSessionConfig> {
+    MegolmSessionConfig(vodozemac::megolm::SessionConfig::version_2()).into()
+}
+
+pub fn megolm_session_config_default() -> Box<MegolmSessionConfig> {
+    MegolmSessionConfig(vodozemac::megolm::SessionConfig::default()).into()
+}
 
 pub struct GroupSession(vodozemac::megolm::GroupSession);
 
-pub fn new_group_session(session_config: &SessionConfig) -> Box<GroupSession> {
+pub fn new_group_session(session_config: &MegolmSessionConfig) -> Box<GroupSession> {
     GroupSession::new(session_config).into()
 }
 
@@ -46,7 +58,7 @@ impl ExportedSessionKey {
 }
 
 impl GroupSession {
-    fn new(session_config: &SessionConfig) -> Self {
+    fn new(session_config: &MegolmSessionConfig) -> Self {
         Self(vodozemac::megolm::GroupSession::new(session_config.0))
     }
 
@@ -78,11 +90,11 @@ pub fn group_session_from_pickle(pickle: &str, pickle_key: &[u8; 32]) -> Result<
 
 pub struct InboundGroupSession(vodozemac::megolm::InboundGroupSession);
 
-pub fn new_inbound_group_session(session_key: &SessionKey, session_config: &SessionConfig) -> Box<InboundGroupSession> {
+pub fn new_inbound_group_session(session_key: &SessionKey, session_config: &MegolmSessionConfig) -> Box<InboundGroupSession> {
     InboundGroupSession::new(session_key, session_config).into()
 }
 
-pub fn import_inbound_group_session(session_key: &ExportedSessionKey, session_config: &SessionConfig) -> Box<InboundGroupSession> {
+pub fn import_inbound_group_session(session_key: &ExportedSessionKey, session_config: &MegolmSessionConfig) -> Box<InboundGroupSession> {
     InboundGroupSession::import(session_key, &session_config).into()
 }
 
@@ -95,11 +107,11 @@ pub fn inbound_group_session_from_pickle(
 }
 
 impl InboundGroupSession {
-    fn new(session_key: &SessionKey, session_config: &SessionConfig) -> Self {
+    fn new(session_key: &SessionKey, session_config: &MegolmSessionConfig) -> Self {
         Self(vodozemac::megolm::InboundGroupSession::new(&session_key.0, session_config.0))
     }
 
-    fn import(session_key: &ExportedSessionKey, session_config: &SessionConfig) -> Self {
+    fn import(session_key: &ExportedSessionKey, session_config: &MegolmSessionConfig) -> Self {
         Self(vodozemac::megolm::InboundGroupSession::import(
             &session_key.0,
             session_config.0,

--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -9,10 +9,14 @@ use group_sessions::{
     exported_session_key_from_base64, group_session_from_pickle, import_inbound_group_session,
     inbound_group_session_from_pickle, megolm_message_from_base64, new_group_session,
     new_inbound_group_session, session_key_from_base64, ExportedSessionKey, GroupSession,
-    InboundGroupSession, MegolmMessage, SessionKey, SessionConfig as GroupSessionConfig,
+    InboundGroupSession, MegolmMessage, SessionKey, MegolmSessionConfig, megolm_session_config_version_1,
+    megolm_session_config_version_2, megolm_session_config_default,
 };
 use sas::{mac_from_base64, new_sas, EstablishedSas, Mac, Sas, SasBytes};
-use session::{session_from_pickle, Session, SessionConfig,};
+use session::{
+    session_from_pickle, Session, OlmSessionConfig, olm_session_config_version_1,
+    olm_session_config_version_2, olm_session_config_default,
+};
 use types::{
     curve_key_from_base64, ed25519_key_from_base64, Curve25519PublicKey, Ed25519PublicKey,
     Ed25519Signature,
@@ -74,7 +78,7 @@ mod ffi {
         fn pickle(self: &Account, pickle_key: &[u8; 32]) -> String;
         fn create_outbound_session(
             self: &Account,
-            session_config: &SessionConfig,
+            session_config: &OlmSessionConfig,
             identity_key: &Curve25519PublicKey,
             one_time_key: &Curve25519PublicKey,
         ) -> Result<Box<Session>>;
@@ -88,7 +92,10 @@ mod ffi {
         fn created(self: &OneTimeKeyGenerationResult) -> Vec<Curve25519PublicKey>;
         fn removed(self: &OneTimeKeyGenerationResult) -> Vec<Curve25519PublicKey>;
 
-        type SessionConfig;
+        type OlmSessionConfig;
+        fn olm_session_config_version_1() -> Box<OlmSessionConfig>;
+        fn olm_session_config_version_2() -> Box<OlmSessionConfig>;
+        fn olm_session_config_default() -> Box<OlmSessionConfig>;
 
         type Session;
         fn session_id(self: &Session) -> String;
@@ -124,10 +131,13 @@ mod ffi {
         fn exported_session_key_from_base64(key: &str) -> Result<Box<ExportedSessionKey>>;
         fn to_base64(self: &ExportedSessionKey) -> String;
 
-        type GroupSessionConfig;
+        type MegolmSessionConfig;
+        fn megolm_session_config_version_1() -> Box<MegolmSessionConfig>;
+        fn megolm_session_config_version_2() -> Box<MegolmSessionConfig>;
+        fn megolm_session_config_default() -> Box<MegolmSessionConfig>;
 
         type GroupSession;
-        fn new_group_session(session_config: &GroupSessionConfig) -> Box<GroupSession>;
+        fn new_group_session(session_config: &MegolmSessionConfig) -> Box<GroupSession>;
         fn encrypt(self: &mut GroupSession, plaintext: &str) -> Box<MegolmMessage>;
         fn session_id(self: &GroupSession) -> String;
         fn session_key(self: &GroupSession) -> Box<SessionKey>;
@@ -139,10 +149,10 @@ mod ffi {
         ) -> Result<Box<GroupSession>>;
 
         type InboundGroupSession;
-        fn new_inbound_group_session(session_key: &SessionKey, session_config: &GroupSessionConfig) -> Box<InboundGroupSession>;
+        fn new_inbound_group_session(session_key: &SessionKey, session_config: &MegolmSessionConfig) -> Box<InboundGroupSession>;
         fn import_inbound_group_session(
             session_key: &ExportedSessionKey,
-            session_config: &GroupSessionConfig,
+            session_config: &MegolmSessionConfig,
         ) -> Box<InboundGroupSession>;
         fn decrypt(
             self: &mut InboundGroupSession,

--- a/cpp/src/session.rs
+++ b/cpp/src/session.rs
@@ -1,5 +1,19 @@
 use super::{ffi::SessionKeys, Curve25519PublicKey, OlmMessage};
 
+pub struct OlmSessionConfig(pub(crate) vodozemac::olm::SessionConfig);
+
+pub fn olm_session_config_version_1() -> Box<OlmSessionConfig> {
+    OlmSessionConfig(vodozemac::olm::SessionConfig::version_1()).into()
+}
+
+pub fn olm_session_config_version_2() -> Box<OlmSessionConfig> {
+    OlmSessionConfig(vodozemac::olm::SessionConfig::version_2()).into()
+}
+
+pub fn olm_session_config_default() -> Box<OlmSessionConfig> {
+    OlmSessionConfig(vodozemac::olm::SessionConfig::default()).into()
+}
+
 pub struct Session(pub(crate) vodozemac::olm::Session);
 
 impl Session {
@@ -45,5 +59,3 @@ pub fn session_from_pickle(
     let pickle = vodozemac::olm::SessionPickle::from_encrypted(pickle, pickle_key)?;
     Ok(Session(vodozemac::olm::Session::from_pickle(pickle)).into())
 }
-
-pub struct SessionConfig(pub(crate) vodozemac::olm::SessionConfig);

--- a/cpp/src/session.rs
+++ b/cpp/src/session.rs
@@ -15,7 +15,7 @@ impl Session {
         OlmMessage(self.0.encrypt(plaintext)).into()
     }
 
-    pub fn decrypt(&mut self, message: &OlmMessage) -> Result<String, anyhow::Error> {
+    pub fn decrypt(&mut self, message: &OlmMessage) -> Result<Vec<u8>, anyhow::Error> {
         Ok(self.0.decrypt(&message.0)?)
     }
 
@@ -45,3 +45,5 @@ pub fn session_from_pickle(
     let pickle = vodozemac::olm::SessionPickle::from_encrypted(pickle, pickle_key)?;
     Ok(Session(vodozemac::olm::Session::from_pickle(pickle)).into())
 }
+
+pub struct SessionConfig(pub(crate) vodozemac::olm::SessionConfig);

--- a/cpp/tests/group_session.cpp
+++ b/cpp/tests/group_session.cpp
@@ -1,7 +1,9 @@
 #include "../../target/cxxbridge/vodozemac/src/lib.rs.h"
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 using namespace rust;
+using testing::ElementsAreArray;
 
 std::array<uint8_t, 32> PICKLE_KEY = {};
 
@@ -10,10 +12,10 @@ struct SessionCreationResult {
   Box<megolm::InboundGroupSession> inbound;
 };
 
-SessionCreationResult create_session() {
-  auto outbound = megolm::new_group_session();
+SessionCreationResult create_session(const megolm::MegolmSessionConfig& session_config) {
+  auto outbound = megolm::new_group_session(session_config);
   auto session_key = outbound->session_key();
-  auto inbound = megolm::new_inbound_group_session(*session_key);
+  auto inbound = megolm::new_inbound_group_session(*session_key, session_config);
 
   auto ret = SessionCreationResult{
       std::move(outbound),
@@ -24,7 +26,7 @@ SessionCreationResult create_session() {
 }
 
 TEST(GroupSessionTest, Creation) {
-  auto [outbound, inbound] = create_session();
+  auto [outbound, inbound] = create_session(*megolm::megolm_session_config_default());
 
   auto outbound_id = outbound->session_id();
   auto inbound_id = inbound->session_id();
@@ -34,20 +36,21 @@ TEST(GroupSessionTest, Creation) {
 }
 
 TEST(GroupSessionTest, MessageIndex) {
-  auto [outbound, inbound] = create_session();
+  auto session_config = megolm::megolm_session_config_default();
+  auto [outbound, inbound] = create_session(*session_config);
 
   EXPECT_EQ(outbound->message_index(), 0);
   EXPECT_EQ(inbound->first_known_index(), 0);
 
   outbound->encrypt("Hello");
-  auto inbound2 = megolm::new_inbound_group_session(*outbound->session_key());
+  auto inbound2 = megolm::new_inbound_group_session(*outbound->session_key(), *session_config);
 
   EXPECT_EQ(outbound->message_index(), 1);
   EXPECT_EQ(inbound2->first_known_index(), 1);
 }
 
 TEST(GroupSessionTest, Pickle) {
-  auto session = megolm::new_group_session();
+  auto session = megolm::new_group_session(*megolm::megolm_session_config_default());
 
   auto pickle = session->pickle(PICKLE_KEY);
   auto unpickled = megolm::group_session_from_pickle(pickle, PICKLE_KEY);
@@ -57,7 +60,7 @@ TEST(GroupSessionTest, Pickle) {
 }
 
 TEST(GroupSessionTest, PickleInbound) {
-  auto [outbound, inbound] = create_session();
+  auto [outbound, inbound] = create_session(*megolm::megolm_session_config_default());
 
   auto pickle = inbound->pickle(PICKLE_KEY);
   auto unpickled =
@@ -73,35 +76,37 @@ TEST(GroupSessionTest, UnpicklingFail) {
 }
 
 TEST(GroupSessionTest, DecryptionFail) {
-  auto [outbound, inbound] = create_session();
+  auto session_config = megolm::megolm_session_config_default();
+  auto [outbound, inbound] = create_session(*session_config);
 
-  auto outbound2 = megolm::new_group_session();
+  auto outbound2 = megolm::new_group_session(*session_config);
   auto message = outbound2->encrypt("Hello");
 
   EXPECT_ANY_THROW(inbound->decrypt(*message));
 }
 
 TEST(GroupSessionTest, Encryption) {
-  auto [outbound, inbound] = create_session();
+  auto [outbound, inbound] = create_session(*megolm::megolm_session_config_default());
 
   auto plaintext = "It's a secret to everybody";
   auto message = outbound->encrypt(plaintext);
   auto decrypted = inbound->decrypt(*message);
 
-  EXPECT_STREQ(decrypted.plaintext.c_str(), plaintext);
+  EXPECT_THAT(decrypted.plaintext, ElementsAreArray(std::string_view(plaintext)));
   EXPECT_EQ(decrypted.message_index, 0);
 
   plaintext = "Another secret";
   message = outbound->encrypt(plaintext);
   decrypted = inbound->decrypt(*message);
 
-  EXPECT_STREQ(decrypted.plaintext.c_str(), plaintext);
+  EXPECT_THAT(decrypted.plaintext, ElementsAreArray(std::string_view(plaintext)));
   EXPECT_EQ(decrypted.message_index, 1);
 }
 
 TEST(GroupSessionTest, SessionExport) {
-  auto [outbound, inbound] = create_session();
-  auto imported = megolm::import_inbound_group_session(*inbound->export_at(0));
+  auto session_config = megolm::megolm_session_config_default();
+  auto [outbound, inbound] = create_session(*session_config);
+  auto imported = megolm::import_inbound_group_session(*inbound->export_at(0), *session_config);
 
   EXPECT_STREQ(outbound->session_id().c_str(), imported->session_id().c_str());
 
@@ -109,13 +114,13 @@ TEST(GroupSessionTest, SessionExport) {
   auto message = outbound->encrypt(plaintext);
   auto decrypted = imported->decrypt(*message);
 
-  EXPECT_STREQ(decrypted.plaintext.c_str(), plaintext);
+  EXPECT_THAT(decrypted.plaintext, ElementsAreArray(std::string_view(plaintext)));
   EXPECT_EQ(decrypted.message_index, 0);
 
   plaintext = "Another secret";
   message = outbound->encrypt(plaintext);
   decrypted = imported->decrypt(*message);
 
-  EXPECT_STREQ(decrypted.plaintext.c_str(), plaintext);
+  EXPECT_THAT(decrypted.plaintext, ElementsAreArray(std::string_view(plaintext)));
   EXPECT_EQ(decrypted.message_index, 1);
 }

--- a/cpp/tests/session.cpp
+++ b/cpp/tests/session.cpp
@@ -1,7 +1,9 @@
 #include "../../target/cxxbridge/vodozemac/src/lib.rs.h"
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 using namespace rust;
+using testing::ElementsAreArray;
 
 std::array<uint8_t, 32> PICKLE_KEY = {};
 
@@ -22,7 +24,7 @@ SessionCreationResult create_session() {
 
   auto identity_key = bob->curve25519_key();
 
-  auto session = alice->create_outbound_session(*identity_key, *one_time_key);
+  auto session = alice->create_outbound_session(*olm::olm_session_config_default(), *identity_key, *one_time_key);
 
   auto ret = SessionCreationResult{
       std::move(alice),
@@ -81,7 +83,7 @@ TEST(SessionTest, Encryption) {
   EXPECT_STREQ(session->session_id().c_str(),
                bob_session->session_id().c_str());
 
-  EXPECT_STREQ(plaintext, decrypted.c_str());
+  EXPECT_THAT(decrypted, ElementsAreArray(std::string_view(plaintext)));
 }
 
 TEST(SessionTest, InvalidDecryption) {
@@ -107,14 +109,14 @@ TEST(SessionTest, MultipleMessageDecryption) {
   EXPECT_STREQ(session->session_id().c_str(),
                bob_session->session_id().c_str());
 
-  EXPECT_STREQ(plaintext, decrypted.c_str());
+  EXPECT_THAT(decrypted, ElementsAreArray(std::string_view(plaintext)));
 
   plaintext = "Grumble grumble";
 
   message = bob_session->encrypt(plaintext);
   decrypted = session->decrypt(*message);
 
-  EXPECT_STREQ(plaintext, decrypted.c_str());
+  EXPECT_THAT(decrypted, ElementsAreArray(std::string_view(plaintext)));
 }
 
 TEST(SessionTest, PreKeyMatches) {


### PR DESCRIPTION
This is the first draft to update C++ bindings to vodozemac 0.7.0. This update compiles (almost, see question 1 below) and passes the tests. I do have a few questions; the first one I will need some help with, the others I can probably figure out by doing some reading.

1. As is, `cargo build` fails because of a dependency version conflict between cpp bindings (updated to vodozemac version 0.7.0) and the other bindings (they still depend on old versions of vodozemac). I'm not sure what is the best way to resolves this:
   -  One could copy the `cpp` directory out of the cargo workspace and run `cargo build` in the copy. However, if we ask all users to do this, I think it would be quite irritating.
   - We can wait until somebody updates the python and javascript bindings to a recent version of vodozemac and combine the three updates.
   - `vodozemac-bindings-cpp` could be made into a completely separate package. I think, the people working on the updated python binding are following this route, however they plan to be maintaining the binding going forward, and I cannot promise to maintain the C++ binding long-term.
   - Maybe, the top-level `Cargo.toml` can be removed, to make the three bindings completely independent from the Cargo's point of view?

2. When I run `cargo build`, I see among other outputs the file `target/cxxbridge/vodozemac/src/lib.rs.cc`. What is its role for the user? I want to include a minimal README, something that would allow a C++ programmer with no Rust knowledge to know where to start. I would need to mention which of the compile outputs are needed to use the bindings and in what capacity. (I'd also like to know that myself)

3. With cxxbridge, all the bridged functions exist in the same namespace on the Rust side. As a result, on the C++ side I cannot have two functions with the same name, even if they are in different namespaces. I would like to have `olm::session_config_version_1` and `megolm::session_config_version_1`. Instead, I ended up with `olm::olm_session_config_version_1` and `megolm::megolm_session_config_version_1`. These names are too long... Maybe there is a workaround? Or a suggestion for better naming?

4. I did not look yet at any new functionality that was added to vodozemac between 0.1.0 and 0.7.0. Are there any new functions or classes that need to be added to the bindings right away?

5. I have just learned that there is another fork working on the C++ bindings: https://lily-is.land/kazv/vodozemac-bindings and https://iron.lily-is.land/project/view/10/ . Maybe it makes sense to move all the efforts there?